### PR TITLE
adjust permission and allow to tun on PRs

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,6 +2,13 @@ name: Python Tests
 
 on:
   push:
+  pull_request:
+
+permissions:
+  contents: read
+  issues: write
+  checks: write
+  pull-requests: write
 
 jobs:
   test:


### PR DESCRIPTION
## Motivation

This change aims to fix the issue where dependabot is unable to run the GitHub Actions workflows due to insufficient permissions. By explicitly granting the necessary permissions in the workflow file, we ensure that dependabot can perform its operations without encountering permission-related errors.



## Changes

- Updated the Python Tests workflow file to include a permissions block.
- Granted read permissions for contents and write permissions for issues, checks, and pull-requests.
- Allow workflows to run on all pull requests

## TODO

- [x] I've assigned myself to this PR
